### PR TITLE
Update package dependencies to newer version to fix a known vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "url": "github.com/everlytic/merge-branch"
   },
   "dependencies": {
-    "@actions/core": "^1.2.4",
-    "@actions/github": "^4.0.0"
+    "@actions/core": "^1.9.0",
+    "@actions/github": "^5.0.0"
   },
   "devDependencies": {
     "@zeit/ncc": "^0.22.3"


### PR DESCRIPTION
One of our users requested to use this action and we always run a security scan before forking the repo (see for example more info in this [blogpost](https://devopsjournal.io/blog/2021/10/14/GitHub-Actions-Internal-Marketplace)).

Our scan found you are using a vulnerable version of [actions/core < 1.2.6](https://github.com/advisories/GHSA-mfwh-5m23-j46w) that we would like to see updated before we start using the action. I can image the other [users](https://github.com/everlytic/branch-merge/network/dependents) of the action would also like to use a non-vulnerable version 😄.

Since issues are not enabled on this repo, I started off with the beginning of a PR to help fix this. I don't have access to npm where I currently am, but I am happy to also push the package-lock.json and contents of the dist folder into this PR. 

Will do so later (hopefully today, CEST)

PS: Maybe it is a good idea to subscribe to security alerts using Dependabot: it's free for Public repos and can automatically update your dependencies if there is a known vulnerability in them.