### PR TITLE
update from Node12 to Node16 

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
     required: false
     default: 'Merged {source_ref} into {target_branch}.'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: git-merge


### PR DESCRIPTION
The GitHub Actions workflow gives the following annotation while running the action.

> [action_commit]
> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: everlytic/branch-merge@1.1.2

So we need to update Node version from 12 to 16.  
