### PR TITLE
Use node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
     required: false
     default: 'Merged {source_ref} into {target_branch}.'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: git-merge


### PR DESCRIPTION
### Sumary of the issue

Node 16 has reached his end of life, and [GitHub recommends to use Node 20](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20).

cc: @everlytic
